### PR TITLE
Support nesting of a single context manager instance for fromdir

### DIFF
--- a/codado/py.py
+++ b/codado/py.py
@@ -160,6 +160,7 @@ class fromdir(object):
     """
     def __init__(self, *paths):
         paths = list(paths)
+        self._origDir = []
         self.path = ''
         for cur in paths:
             cur = os.path.expanduser(cur)
@@ -173,12 +174,12 @@ class fromdir(object):
         return os.path.join(*a)
 
     def __enter__(self):
-        self._origDir = os.getcwd()
+        self._origDir.append(os.getcwd())
         os.chdir(self.path)
         return self
 
     def __exit__(self, type, value, tb):
-        os.chdir(self._origDir)
+        os.chdir(self._origDir.pop())
 
 
 def remoji():

--- a/codado/test/test_py.py
+++ b/codado/test/test_py.py
@@ -51,6 +51,21 @@ def test_fromdir():
     assert py.fromdir('~')() == os.environ['HOME']
 
 
+def test_fromdirNesting():
+    """
+    Test an unrecommended but possible nesting of the same context manager instance.
+    """
+
+    startingCwd = os.getcwd()
+
+    testDir = py.fromdir('..')
+    with testDir:
+        with testDir:
+            pass
+
+    assert startingCwd == os.getcwd()
+
+
 def test_enum():
     """
     Do I permit attribute access to keys?


### PR DESCRIPTION
Adds the ability to nest a single context manager instance of `fromdir`. I first wrote a test to show the failure then modified `fromdir` to pass. The implementation turns `self._origDir` into a stack/list. 